### PR TITLE
set pose and twist covariance properly

### DIFF
--- a/swerve_controller/src/swerve_controller.cpp
+++ b/swerve_controller/src/swerve_controller.cpp
@@ -218,14 +218,15 @@ controller_interface::CallbackReturn SwerveController::on_configure(const rclcpp
   rt_odom_state_publisher_->msg_.child_frame_id = params_.base_frame_id;
   rt_odom_state_publisher_->msg_.pose.pose.position.z = 0;
 
-  auto & covariance = rt_odom_state_publisher_->msg_.twist.covariance;
+  auto & pose_covariance = rt_odom_state_publisher_->msg_.pose.covariance;
+  auto & twist_covariance = rt_odom_state_publisher_->msg_.twist.covariance;
   constexpr size_t NUM_DIMENSIONS = 6;
   for (size_t index = 0; index < 6; ++index)
   {
     // 0, 7, 14, 21, 28, 35
     const size_t diagonal_index = NUM_DIMENSIONS * index + index;
-    covariance[diagonal_index] = params_.pose_covariance_diagonal[index];
-    covariance[diagonal_index] = params_.twist_covariance_diagonal[index];
+    pose_covariance[diagonal_index] = params_.pose_covariance_diagonal[index];
+    twist_covariance[diagonal_index] = params_.twist_covariance_diagonal[index];
   }
   rt_odom_state_publisher_->unlock();
 
@@ -949,7 +950,7 @@ void SwerveController::brake()
   }
 
   // The steer joints hold the current position
-  int no_of_steer_joints = params_.steer_joints_names.size();
+  size_t no_of_steer_joints = params_.steer_joints_names.size();
 
   for (size_t i = 0; i < no_of_steer_joints; i++)
   {


### PR DESCRIPTION
 - Set pose covariance as well as twist covariance in published message.
 - Also trivial type change to suppress type warning.